### PR TITLE
Ensure mosh is installed on servers

### DIFF
--- a/roles/base/tasks/main.yml
+++ b/roles/base/tasks/main.yml
@@ -30,6 +30,7 @@
   apt:
     name:
       - byobu
+      - mosh
       - zsh
       - curl
       - wget


### PR DESCRIPTION
The first thing I did when ssh'ing into `bbb-test` was to install mosh so we should probably add that to the playbook.