### PR TITLE
Ensure greenlight user has correct primary group

### DIFF
--- a/roles/greenlight/tasks/main.yml
+++ b/roles/greenlight/tasks/main.yml
@@ -12,7 +12,7 @@
     shell: /bin/bash
     password: "!"
     update_password: on_create
-    groups: greenlight
+    group: greenlight
     system: yes
     state: present
 


### PR DESCRIPTION
This corrects a single letter typo - `groups` should be `group`.

See https://docs.ansible.com/ansible/latest/modules/user_module.html#parameter-group.