### PR TITLE
Ensure kernel entropy pool seeding daemon is installed

### DIFF
--- a/roles/base/tasks/main.yml
+++ b/roles/base/tasks/main.yml
@@ -92,6 +92,5 @@
     name:
       - entropyclient
     state: present
-    update_cache: yes
 
 - import_tasks: firewall.yml

--- a/roles/base/tasks/main.yml
+++ b/roles/base/tasks/main.yml
@@ -83,4 +83,15 @@
     state: absent
   notify: restart sshd
 
+- name: Ensure malc's PPA is added to the system
+  apt_repository:
+    repo: ppa:malcscott/entropy
+
+- name: Ensure kernel entropy pool seeding daemon is installed
+  apt:
+    name:
+      - entropyclient
+    state: present
+    update_cache: yes
+
 - import_tasks: firewall.yml


### PR DESCRIPTION
This PR adds the necessary playbook steps to ensure that entropyclient is installed.

@mas90 please could you review and check that I've got the correct steps for your PPA? 😄 