### PR TITLE
Configure dynamic video profiles, running three parallel Kurento media servers

### DIFF
--- a/roles/bbb-srcf/files/apply-config.sh
+++ b/roles/bbb-srcf/files/apply-config.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+# Pull in the helper functions for configuring BigBlueButton
+source /etc/bigbluebutton/bbb-conf/apply-lib.sh
+
+enableMultipleKurentos

--- a/roles/bbb-srcf/tasks/main.yml
+++ b/roles/bbb-srcf/tasks/main.yml
@@ -7,6 +7,13 @@
       - mp4
   notify: restart bigbluebutton
 
+- name: copy apply-config
+  copy:
+    src: apply-config.sh
+    dest: /etc/bigbluebutton/bbb-conf/apply-config.sh
+    mode: 0755
+  notify: restart bigbluebutton
+
 - name: ensure default recording is enabled
   lineinfile:
     path: /usr/share/bbb-web/WEB-INF/classes/bigbluebutton.properties

--- a/vars.yml
+++ b/vars.yml
@@ -20,14 +20,18 @@ bbb_meteor:
       clientTitle: "SRCF Timeout VC"
     kurento:
       cameraProfiles:
+      - id: low-u8
+        bitrate: 90
+      - id: low-u12
+        bitrate: 80
       - id: low
         name: Low quality
         default: false
-        bitrate: 50
+        bitrate: 100
       - id: medium
         name: Medium quality
         default: true
-        bitrate: 100
+        bitrate: 150
       - id: high
         name: High quality
         default: false
@@ -36,8 +40,22 @@ bbb_meteor:
         name: High definition
         default: false
         bitrate: 400
+        hidden: true
       cameraQualityThresholds:
         enabled: true
+        thresholds:
+        - threshold: 8
+          profile: low-u8
+        - threshold: 12
+          profile: low-u12
+        - threshold: 15
+          profile: low-u15
+        - threshold: 20
+          profile: low-u20
+        - threshold: 25
+          profile: low-u25
+        - threshold: 30
+          profile: low-u30
 
 mail_admin:
   {

--- a/vars.yml
+++ b/vars.yml
@@ -36,6 +36,8 @@ bbb_meteor:
         name: High definition
         default: false
         bitrate: 400
+      cameraQualityThresholds:
+        enabled: true
 
 mail_admin:
   {

--- a/vars.yml
+++ b/vars.yml
@@ -43,19 +43,6 @@ bbb_meteor:
         hidden: true
       cameraQualityThresholds:
         enabled: true
-        thresholds:
-        - threshold: 8
-          profile: low-u8
-        - threshold: 12
-          profile: low-u12
-        - threshold: 15
-          profile: low-u15
-        - threshold: 20
-          profile: low-u20
-        - threshold: 25
-          profile: low-u25
-        - threshold: 30
-          profile: low-u30
 
 mail_admin:
   {


### PR DESCRIPTION
Configure these new features before upgrading to 2.2.25.

- Dynamic video profiles: simply enabled for now, using the default threshold. I imagine the thresholds will have to be tweaked to suit our setup. See https://github.com/bigbluebutton/bigbluebutton/blob/629e2dbfd46632ee2bb2d6e89fdedfb39e5483a8/bigbluebutton-html5/private/config/settings.yml#L184-L198 for the default thresholds, which are defined under `cameraProfiles` just above.

- Run three parallel Kurento media servers: created an `apply-config.sh` file which is copied to the servers during the `bbb-srcf` role. In this file we enable the parallel KMSs as per https://docs.bigbluebutton.org/2.2/customize.html#run-three-parallel-kurento-media-servers.

Addresses #8, but pagination has not been enabled for now.

